### PR TITLE
Add support for listening on unix sockets

### DIFF
--- a/proxy/client.go
+++ b/proxy/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -134,6 +135,9 @@ func (c *Client) Run(ctx context.Context) error {
 func (c *Client) getListener() (net.Listener, error) {
 	if strings.HasPrefix(c.localAddr, "unix://") {
 		p := strings.TrimPrefix(c.localAddr, "unix://")
+		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+			return nil, fmt.Errorf("failed to remove unix domain socket file %s, error: %s", p, err)
+		}
 		return net.Listen("unix", p)
 	}
 	return net.Listen("tcp", c.localAddr)


### PR DESCRIPTION
This is a very small PR that allows a user to pass in a unix socket location that the proxy can listen on. This looks like:

```
./sql-proxy-client -token "[REDACTED]" -instance "nick/test/test" -local-addr "unix:///tmp/proxy.sock"
2021-02-12T10:39:49.711-0800	INFO	proxy/client.go:334	adding tls.Config to the cache	{"app": "sql-proxy-client", "instance": "nick/test/test"}
2021-02-12T10:39:49.712-0800	INFO	proxy/client.go:124	ready for new connections	{"app": "sql-proxy-client"}
2021-02-12T10:39:49.712-0800	INFO	proxy/client.go:179	listening remote DB instance	{"app": "sql-proxy-client", "local_addr": "unix:///tmp/proxy.sock", "instance": "nick/test/test"}
```

Unix Sockets don't need to support keepalives, so you get a warning, but it is completely harmless. On the MySQL side, this looks like:

```
~> mysql -uroot -p --socket /tmp/proxy.sock
mysql: [Warning] Using a password on the command line interface can be insecure.
Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 626884
Server version: 5.7.9-Vitess MySQL Community Server - GPL
```

Works like a charm!