### PR TITLE
Fix goreleaser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.15
+        go-version: ^1.16
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
@@ -38,7 +38,7 @@ jobs:
       # only release on tags
       if: success() && startsWith(github.ref, 'refs/tags/')
       with:
-        version: latest
+        version: v0.156.2
         args: release --rm-dist
       env:
         GITHUB_TOKEN: ${{ secrets.PLANETSCALE_ACTIONS_BOT_TOKEN }}


### PR DESCRIPTION
`goreleaser` is broken with Go v1.15.  We already fixed it in the CLI
repo. Let's also fix the versioning here.
