### PR TITLE
Populate proxy.Cert with remote ports

### DIFF
--- a/cmd/sql-proxy-client/main.go
+++ b/cmd/sql-proxy-client/main.go
@@ -132,6 +132,10 @@ func (r *remoteCertSource) Cert(ctx context.Context, org, db, branch string) (*p
 		ClientCert: cert.ClientCert,
 		CACert:     cert.CACert,
 		RemoteAddr: cert.RemoteAddr,
+		Ports: proxy.RemotePorts{
+			MySQL: cert.Ports.MySQL,
+			Proxy: cert.Ports.Proxy,
+		},
 	}, nil
 }
 


### PR DESCRIPTION
We don't pull these in from the cert right now, which means we always try to connect to the default value (`0`), which doesn't work.

Closes https://github.com/planetscale/sql-proxy/issues/67