### PR TITLE
Add Docker container support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,6 +12,18 @@ builds:
     ldflags:
      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
     binary: "pscale-proxy"   
+dockers:
+  - image_templates:
+    - "planetscale/pscale-proxy:latest"
+    - "planetscale/pscale-proxy:{{ .Tag }}"
+    build_flag_templates:
+    - "--pull"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.title={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=org.opencontainers.image.source={{.GitURL}}"
+    dockerfile: Dockerfile.goreleaser
 nfpms:
   - maintainer: PlanetScale
     description: The PlanetScale SQL Proxy
@@ -49,3 +61,4 @@ changelog:
     exclude:
       - '^docs:'
       - '^test:'
+      - Merge pull request

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:1.16 as build
+WORKDIR /app
+COPY . .
+
+ARG VERSION
+ARG COMMIT
+ARG DATE
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-X main.commit=$COMMIT -X main.version=$VERSION -X main.date=$DATE" -o pscale-proxy github.com/planetscale/sql-proxy/cmd/sql-proxy-client
+
+FROM alpine:latest  
+RUN apk --no-cache add ca-certificates
+EXPOSE 3306
+
+WORKDIR /app
+COPY --from=build /app/pscale-proxy /usr/bin
+ENTRYPOINT ["/usr/bin/pscale-proxy"] 

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,0 +1,6 @@
+FROM alpine:latest  
+RUN apk --no-cache add ca-certificates
+EXPOSE 3306
+
+COPY pscale-proxy /usr/bin
+ENTRYPOINT ["/usr/bin/pscale-proxy"] 

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,27 @@
+COMMIT := $(shell git rev-parse --short=7 HEAD 2>/dev/null)
+VERSION := $(shell git describe --abbrev=0 HEAD 2>/dev/null)
+DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+ifeq ($(strip $(shell git status --porcelain 2>/dev/null)),)
+  GIT_TREE_STATE=clean
+else
+  GIT_TREE_STATE=dirty
+endif
+
+REPO=planetscale
+NAME=pscale-proxy
+BUILD_PKG=github.com/planetscale/sql-proxy/cmd/sql-proxy-client
+
 .PHONY: all
 all: build test lint
 
 .PHONY: test
 test:
-	go test ./...
+	@go test ./...
 
 .PHONY: build
 build:
-	go build ./...
+	@go build ./...
 
 .PHONY: lint
 lint: 
@@ -19,3 +33,25 @@ licensed:
 	licensed cache
 	licensed status
 
+
+.PHONY: build-image
+build-image: 
+	@echo "==> Building docker image ${REPO}/${NAME}:$(VERSION)"
+	@# Permit building only if the Git tree is clean
+	# @echo "${GIT_TREE_STATE}" | grep -Eq "^clean" || ( echo "Git tree state is not clean"; exit 1 )
+	@docker build --build-arg VERSION=$(VERSION:v%=%) --build-arg COMMIT=$(COMMIT) --build-arg DATE=$(DATE) -t ${REPO}/${NAME}:$(VERSION) .
+	@docker tag ${REPO}/${NAME}:$(VERSION) ${REPO}/${NAME}:latest
+
+.PHONY: push
+push:
+	@# Permit releasing only if VERSION adheres to semver.
+	@echo "${VERSION}" | grep -Eq "^v[0-9]+\.[0-9]+\.[0-9]+$$" || ( echo "VERSION \"${VERSION}\" does not adhere to semver"; exit 1 )
+	@echo "==> Pushing docker image ${REPO}/${NAME}:$(VERSION)"
+	@docker push ${REPO}/${NAME}:latest
+	@docker push ${REPO}/${NAME}:$(VERSION)
+	@echo "==> Your image is now available at $(REPO)/${NAME}:$(VERSION)"
+
+.PHONY: clean
+clean:
+	@echo "==> Cleaning artifacts"
+	@rm ${NAME}

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ Authenticate with [`pscale`](https://github.com/planetscale/cli):
 pscale auth login
 ```
 
-Run the proxy by passing the `organization/database/branch` combination you want to connect:
+Run the proxy by passing your organization, database and the branch you want to connect:
 
 ```
-sql-proxy-client --token "$(cat ~/.config/planetscale/access-token)" --instance "org/db/branch" 
+sql-proxy-client --token "$(cat ~/.config/planetscale/access-token)" --org "org" --database "db" --branch "branch" 
 ```
 This will run the `sql-proxy-client` on your localhost and bind to the address
 `127.0.0.1:3307`. You should use this address to connect your application. As
@@ -43,26 +43,33 @@ an example, here is how you can connect with the `mysql` CLI:
 mysql -u root -h 127.0.0.1 -P 3307
 ```
 
-## Development
+### Connecting with a Service token
 
-### Releasing a new version
-
-To release a new version of the `sql-proxy` make sure to switch to an updated `main` branch:
+To connect with a service token and service token name, use the following flags:
 
 ```
-git checkout main
-git pull origin main
+sql-proxy-client --service-token "<your_service_token>" --service-token-name "<your_service_token_name>" --org "org" --database "db" --branch "branch" 
+```
+## Using the Docker container
+
+We also provide ready to use containers. To pull the latest docker image:
+
+```
+docker pull planetscale/pscale-proxy:latest
 ```
 
-after that create a new tag and push to the repo. Make sure the version is bumped:
+Here is an example to run the container and publish the proxy on host address
+`127.0.0.1:3306:`
 
 ```
-git tag -a <version> -m <comment>
-git push origin <version>
+$ docker run -p 127.0.0.1:3306:3306 planetscale/pscale-proxy \
+  --host 0.0.0.0 \
+  --org "$PLANETSCALE_ORG" \
+  --database "$PLANETSCALE_DATABASE" \
+  --branch "$PLANETSCALE_BRANCH" \
+  --service-token "$PLANETSCALE_SERVICE_TOKEN" \
+  --service-token-name "$PLANETSCALE_SERVICE_TOKEN_NAME" 
 ```
-
-This will trigger the CI and invoke `goreleaser`, which will then release all the appropriate packages and archives.
-
 
 ## Credits
 


### PR DESCRIPTION
This PR adds a Dockerfile to containerize the `cmd/sql-proxy-client` binary. It's similar to what we have done in our CLI repository: https://github.com/planetscale/cli/pull/289

Here is an example to run the container and publish the proxy on host address `127.0.0.1:3306:`

```
$ docker run -p 127.0.0.1:3306:3306 planetscale/pscale-proxy:latest \
  --host 0.0.0.0 \
  --org "$PLANETSCALE_ORG" \
  --database "$PLANETSCALE_DATABASE" \
  --branch "$PLANETSCALE_BRANCH" \
  --service-token "$PLANETSCALE_SERVICE_TOKEN" \
  --service-token-name "$PLANETSCALE_SERVICE_TOKEN_NAME" 
```
