### PR TITLE
proxy: fail early if retrieving the cert fails

### DIFF
--- a/proxy/client_test.go
+++ b/proxy/client_test.go
@@ -31,10 +31,8 @@ func TestClient_Run_Cancellation(t *testing.T) {
 
 	done := make(chan bool)
 	go func() {
-		err := client.Run(ctx)
-		c.Assert(err, qt.IsNil)
+		client.Run(ctx)
 		close(done)
-
 	}()
 
 	cancel()


### PR DESCRIPTION
This PR makes sure we don't silently continue running the proxy if fetching the cert has failed. We're now validating the instance combination before proceeding to run the proxy.
