### PR TITLE
Enforce TLS 1.2 as minimal version for the client

### DIFF
--- a/proxy/client.go
+++ b/proxy/client.go
@@ -349,6 +349,7 @@ func (c *Client) clientCerts(ctx context.Context, instance string) (*tls.Config,
 	cfg := &tls.Config{
 		ServerName:   serverName,
 		Certificates: []tls.Certificate{cert.ClientCert},
+		MinVersion:   tls.VersionTLS12,
 		RootCAs:      rootCertPool,
 		// Set InsecureSkipVerify to skip the default validation we are
 		// replacing. This will not disable VerifyConnection.

--- a/proxy/client_test.go
+++ b/proxy/client_test.go
@@ -101,7 +101,7 @@ func TestClient_clientCerts_has_cache(t *testing.T) {
 	client, err := NewClient(testOpts)
 	c.Assert(err, qt.IsNil)
 
-	cfg := &tls.Config{ServerName: "server"}
+	cfg := &tls.Config{ServerName: "server", MinVersion: tls.VersionTLS12}
 	remoteAddr := "foo.example.com"
 	client.configCache.Add(instance, cfg, remoteAddr)
 

--- a/proxy/tls_cache_test.go
+++ b/proxy/tls_cache_test.go
@@ -14,7 +14,7 @@ func TestTLSCache_Retrieve(t *testing.T) {
 	cache := newtlsCache()
 
 	instance := "foo"
-	cfg := &tls.Config{ServerName: "server"}
+	cfg := &tls.Config{ServerName: "server", MinVersion: tls.VersionTLS12}
 	remoteAddr := "foo.example.com:3306"
 
 	cache.Add(instance, cfg, remoteAddr)
@@ -45,7 +45,7 @@ func TestTLSCache_Expired(t *testing.T) {
 	}
 
 	instance := "foo"
-	cfg := &tls.Config{ServerName: "server"}
+	cfg := &tls.Config{ServerName: "server", MinVersion: tls.VersionTLS12}
 	remoteAddr := "foo.example.com:3306"
 
 	cache.Add(instance, cfg, remoteAddr)


### PR DESCRIPTION
This is already enforced server side but good to do on the client too. 