### PR TITLE
Remove wrapped error for getting a certificate

### DIFF
--- a/proxy/client.go
+++ b/proxy/client.go
@@ -334,7 +334,7 @@ func (c *Client) clientCerts(ctx context.Context, instance string) (*tls.Config,
 
 	cert, err := c.certSource.Cert(ctx, s[0], s[1], s[2])
 	if err != nil {
-		return nil, "", fmt.Errorf("couldn't retrieve certs from cert source: %s", err)
+		return nil, "", err
 	}
 
 	fullAddr := fmt.Sprintf("%s:%d", cert.AccessHost, cert.Ports.Proxy)


### PR DESCRIPTION
When a user does not have permissions to fetch a certificate, we return an error message.

For example, using this in the CLI looks something like this...

`Error: couldn't retrieve certs from cert source: User does not have permission to perform this action.`

I don't think this is a user-friendly error message, to be honest, we really only care about the underlying error: the user not having permission to perform this action. This removes the wrapped error so it looks somewhat nicer.