### PR TITLE
Attempt to fix CI

### DIFF
--- a/.licenses/go/github.com/matoous/go-nanoid/v2.dep.yml
+++ b/.licenses/go/github.com/matoous/go-nanoid/v2.dep.yml
@@ -1,15 +1,16 @@
 ---
-name: go.uber.org/zap/zapcore
-version: v1.19.0
+name: github.com/matoous/go-nanoid/v2
+version: v2.0.0
 type: go
-summary: Package zapcore defines and implements the low-level interfaces upon which
-  zap is built.
-homepage: https://pkg.go.dev/go.uber.org/zap/zapcore
+summary:
+homepage: https://pkg.go.dev/github.com/matoous/go-nanoid/v2
 license: mit
 licenses:
-- sources: zap@v1.19.0/LICENSE.txt
+- sources: LICENSE
   text: |
-    Copyright (c) 2016-2017 Uber Technologies, Inc.
+    The MIT License (MIT)
+
+    Copyright (c) 2018 Matous Dzivjak <matousdzivjak@gmail.com>
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal
@@ -28,4 +29,6 @@ licenses:
     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
     THE SOFTWARE.
+- sources: README.md
+  text: The MIT License (MIT). Please see [License File](LICENSE.md) for more information.
 notices: []

--- a/.licenses/go/github.com/planetscale/planetscale-go/planetscale.dep.yml
+++ b/.licenses/go/github.com/planetscale/planetscale-go/planetscale.dep.yml
@@ -1,13 +1,14 @@
 ---
 name: github.com/planetscale/planetscale-go/planetscale
-version: v0.25.0
+version: v0.51.0
 type: go
-summary: 
-homepage: https://godoc.org/github.com/planetscale/planetscale-go/planetscale
+summary:
+homepage: https://pkg.go.dev/github.com/planetscale/planetscale-go/planetscale
 license: apache-2.0
 licenses:
-- sources: LICENSE
+- sources: planetscale-go@v0.51.0/LICENSE
   text: |2
+
                                      Apache License
                                Version 2.0, January 2004
                             http://www.apache.org/licenses/
@@ -182,4 +183,31 @@ licenses:
           defend, and hold each Contributor harmless for any liability
           incurred by, or claims asserted against, such Contributor by reason
           of your accepting any such warranty or additional liability.
+
+       END OF TERMS AND CONDITIONS
+
+       APPENDIX: How to apply the Apache License to your work.
+
+          To apply the Apache License to your work, attach the following
+          boilerplate notice, with the fields enclosed by brackets "[]"
+          replaced with your own identifying information. (Don't include
+          the brackets!)  The text should be enclosed in the appropriate
+          comment syntax for the file format. We also recommend that a
+          file or class name and description of purpose be included on the
+          same "printed page" as the copyright notice for easier
+          identification within third-party archives.
+
+       Copyright 2021 PlanetScale, Inc.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
 notices: []

--- a/.licenses/go/go.uber.org/zap.dep.yml
+++ b/.licenses/go/go.uber.org/zap.dep.yml
@@ -1,9 +1,9 @@
 ---
 name: go.uber.org/zap
-version: v1.16.0
+version: v1.19.0
 type: go
 summary: Package zap provides fast, structured, leveled logging.
-homepage: https://godoc.org/go.uber.org/zap
+homepage: https://pkg.go.dev/go.uber.org/zap
 license: mit
 licenses:
 - sources: LICENSE.txt

--- a/.licenses/go/go.uber.org/zap/buffer.dep.yml
+++ b/.licenses/go/go.uber.org/zap/buffer.dep.yml
@@ -1,12 +1,12 @@
 ---
 name: go.uber.org/zap/buffer
-version: v1.16.0
+version: v1.19.0
 type: go
 summary: Package buffer provides a thin wrapper around a byte slice.
-homepage: https://godoc.org/go.uber.org/zap/buffer
+homepage: https://pkg.go.dev/go.uber.org/zap/buffer
 license: mit
 licenses:
-- sources: zap@v1.16.0/LICENSE.txt
+- sources: zap@v1.19.0/LICENSE.txt
   text: |
     Copyright (c) 2016-2017 Uber Technologies, Inc.
 

--- a/.licenses/go/go.uber.org/zap/internal/bufferpool.dep.yml
+++ b/.licenses/go/go.uber.org/zap/internal/bufferpool.dep.yml
@@ -1,12 +1,12 @@
 ---
 name: go.uber.org/zap/internal/bufferpool
-version: v1.16.0
+version: v1.19.0
 type: go
 summary: Package bufferpool houses zap's shared internal buffer pool.
-homepage: https://godoc.org/go.uber.org/zap/internal/bufferpool
+homepage: https://pkg.go.dev/go.uber.org/zap/internal/bufferpool
 license: mit
 licenses:
-- sources: zap@v1.16.0/LICENSE.txt
+- sources: zap@v1.19.0/LICENSE.txt
   text: |
     Copyright (c) 2016-2017 Uber Technologies, Inc.
 

--- a/.licenses/go/go.uber.org/zap/internal/color.dep.yml
+++ b/.licenses/go/go.uber.org/zap/internal/color.dep.yml
@@ -1,12 +1,12 @@
 ---
 name: go.uber.org/zap/internal/color
-version: v1.16.0
+version: v1.19.0
 type: go
 summary: Package color adds coloring functionality for TTY output.
-homepage: https://godoc.org/go.uber.org/zap/internal/color
+homepage: https://pkg.go.dev/go.uber.org/zap/internal/color
 license: mit
 licenses:
-- sources: zap@v1.16.0/LICENSE.txt
+- sources: zap@v1.19.0/LICENSE.txt
   text: |
     Copyright (c) 2016-2017 Uber Technologies, Inc.
 

--- a/.licenses/go/go.uber.org/zap/internal/exit.dep.yml
+++ b/.licenses/go/go.uber.org/zap/internal/exit.dep.yml
@@ -1,13 +1,13 @@
 ---
 name: go.uber.org/zap/internal/exit
-version: v1.16.0
+version: v1.19.0
 type: go
 summary: Package exit provides stubs so that unit tests can exercise code that calls
   os.Exit(1).
-homepage: https://godoc.org/go.uber.org/zap/internal/exit
+homepage: https://pkg.go.dev/go.uber.org/zap/internal/exit
 license: mit
 licenses:
-- sources: zap@v1.16.0/LICENSE.txt
+- sources: zap@v1.19.0/LICENSE.txt
   text: |
     Copyright (c) 2016-2017 Uber Technologies, Inc.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16 as build
+FROM golang:1.18.3 as build
 WORKDIR /app
 COPY . .
 
@@ -8,10 +8,10 @@ ARG DATE
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-X main.commit=$COMMIT -X main.version=$VERSION -X main.date=$DATE" -o pscale-proxy github.com/planetscale/sql-proxy/cmd/sql-proxy-client
 
-FROM alpine:latest  
+FROM alpine:latest
 RUN apk --no-cache add ca-certificates
 EXPOSE 3306
 
 WORKDIR /app
 COPY --from=build /app/pscale-proxy /usr/bin
-ENTRYPOINT ["/usr/bin/pscale-proxy"] 
+ENTRYPOINT ["/usr/bin/pscale-proxy"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   app:
-    image: golang:1.16.4
+    image: golang:1.18.3
     volumes:
       - .:/work
     working_dir: /work

--- a/docker/Dockerfile.licensed
+++ b/docker/Dockerfile.licensed
@@ -1,5 +1,5 @@
-FROM ruby:3.1.2-buster
+FROM golang:1.18.3-bullseye
 
 RUN apt-get update && apt-get upgrade -y
-RUN apt-get install -y golang-go cmake pkg-config git-core libgit2-dev
+RUN apt-get install -y ruby-dev ruby rubygems cmake pkg-config git-core libgit2-dev
 RUN gem install licensed

--- a/docker/Dockerfile.licensed
+++ b/docker/Dockerfile.licensed
@@ -1,5 +1,5 @@
-FROM golang:1.16-buster
+FROM ruby:3.1.2-buster
 
 RUN apt-get update && apt-get upgrade -y
-RUN apt-get install -y ruby-dev rubygems ruby cmake pkg-config git-core libgit2-dev
+RUN apt-get install -y golang-go cmake pkg-config git-core libgit2-dev
 RUN gem install licensed

--- a/proxy/client.go
+++ b/proxy/client.go
@@ -222,7 +222,7 @@ func (c *Client) listen(l net.Listener, connSrc chan<- Conn) error {
 		start := time.Now()
 		conn, err := l.Accept()
 		if err != nil {
-			if nerr, ok := err.(net.Error); ok && nerr.Temporary() {
+			if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
 				d := 10*time.Millisecond - time.Since(start)
 				if d > 0 {
 					time.Sleep(d)


### PR DESCRIPTION
When working on #146, I encountered some CI errors. This updates our Dockerfile to the latest version, while additionally bumping up the Go version and getting rid of the use of the now-deprecated `Temporary()` function from `net.Error`. 