### PR TITLE
Enhance listening host configuration in cmd/sql-proxy-client via PLANETSCALE_LISTENING_HOST environment variable

### DIFF
--- a/cmd/sql-proxy-client/main.go
+++ b/cmd/sql-proxy-client/main.go
@@ -41,7 +41,13 @@ func main() {
 }
 
 func realMain() error {
-	host := flag.String("host", os.Getenv("PLANETSCALE_LISTENING_HOST"), "Local host to bind and listen for connections")
+	host := flag.String("host", func() string {
+		if h := os.Getenv("PLANETSCALE_LISTENING_HOST"); h != "" {
+			return h
+		}
+		return "127.0.0.1"
+	}(), "Local host to bind and listen for connections")
+
 	port := flag.String("port", "3306", "Local port to bind and listen for connections")
 
 	remoteHost := flag.String("remote-host", "", "MySQL remote host")

--- a/cmd/sql-proxy-client/main.go
+++ b/cmd/sql-proxy-client/main.go
@@ -41,7 +41,7 @@ func main() {
 }
 
 func realMain() error {
-	host := flag.String("host", "127.0.0.1", "Local host to bind and listen for connections")
+	host := flag.String("host", os.Getenv("PLANETSCALE_LISTENING_HOST"), "Local host to bind and listen for connections")
 	port := flag.String("port", "3306", "Local port to bind and listen for connections")
 
 	remoteHost := flag.String("remote-host", "", "MySQL remote host")


### PR DESCRIPTION
**Summary**

This PR enhances the flexibility of setting the listening host in cmd/sql-proxy-client/main.go. It allows the host to be configured via an environment variable, `PLANETSCALE_LISTENING_HOST`, while maintaining "127.0.0.1" as the default value if the variable is not set.

**Changes**

Modified the host flag to dynamically fetch its value from the `PLANETSCALE_LISTENING_HOST` environment variable, defaulting to "127.0.0.1" if the variable is not set.

**Why**

This change provides users with the ability to easily configure the listening host via an environment variable without losing the convenience of a default value.

**How to Test**

1. Do not set the environment variable `PLANETSCALE_LISTENING_HOST` and run the SQL proxy client. Verify that it listens on the default "127.0.0.1" host.
2. Set the environment variable `PLANETSCALE_LISTENING_HOST` to a desired host.
3. Run the SQL proxy client.
4. Verify that the client is listening on the host specified in the `PLANETSCALE_LISTENING_HOST` environment variable.


Maintainer:

@skottler, please have a look when you can.